### PR TITLE
Added Violentmonkey as first recommended choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installa il pacchetto xpi dalla sezione [releases](https://github.com/gall0ws/fr
 4. seleziona *Load unpacked*
 5. seleziona la directory dove hai clonato il repo
 
-## Greasemonkey / Tampermonkey (Chrome, Safari, Opera Next)
+## Violentmonkey / Greasemonkey (Chrome, Firefox, Safari, Opera Next)
 Crea un user script con il contenuto di `freeRep.js`
 
 NOTA: Con freeRep >= 1.6 il il paywall di Repubblica.it non viene bypassato usando freeRep come script (vedi [PR#15](https://github.com/gall0ws/freeRep/pull/15))


### PR DESCRIPTION
Replaced Tampermonkey with Violentmonkey, which is an open source alternative: https://github.com/violentmonkey/violentmonkey. Violentmonkey is also available for both Chromium- and Firefox-based browsers. Meanwhile, Greasemonkey (which is also open source) is only available for Firefox-based browsers.